### PR TITLE
Remove Unused Sign In Label TapGestureRecognizer

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -57,10 +57,6 @@
                     <Label Text="Sign In"
                    TextColor="Blue"
                    HorizontalOptions="Center">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding TapCommand}"
-                          CommandParameter="https://docs.microsoft.com/dotnet/maui" />
-                        </Label.GestureRecognizers>
                     </Label>
                 </HorizontalStackLayout>
             </VerticalStackLayout>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -9,7 +9,6 @@ namespace SignUpPage
         string UsernameI = "";
         string PasswordI = "";
         string ConfirmPasswordI = "";
-        public ICommand TapCommand = new Command<string>(async (url) => await Launcher.OpenAsync(url));
 
         public MainPage()
         {


### PR DESCRIPTION
Since it's not functional & not required, I've removed this unused `TapGestureRecognizer`.

```diff
# MainPage.xaml
<HorizontalStackLayout>
    <Label Text="Already have an account?" Padding="0,0,4,0"/>
    <Label Text="Sign In"
   TextColor="Blue"
   HorizontalOptions="Center">
-        <Label.GestureRecognizers>
-            <TapGestureRecognizer Command="{Binding TapCommand}"
-          CommandParameter="https://docs.microsoft.com/dotnet/maui" />
-        </Label.GestureRecognizers>
    </Label>
</HorizontalStackLayout>
 ```
 
 Together with its corresponding `Binding` in the code-behind.
 
 ```diff
 # MainPage.xaml.cs
string FirstNameI = "";
string LastNameI = "";
string UsernameI = "";
string PasswordI = "";
string ConfirmPasswordI = "";
- public ICommand TapCommand = new Command<string>(async (url) => await Launcher.OpenAsync(url));
```